### PR TITLE
fix: recent CVE's in reports server

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -134,7 +134,7 @@ require (
 	github.com/go-piv/piv-go v1.11.0 // indirect
 	github.com/gobwas/glob v0.2.3 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
-	github.com/golang-jwt/jwt/v4 v4.5.1 // indirect
+	github.com/golang-jwt/jwt/v4 v4.5.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/golang/snappy v0.0.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -360,8 +360,8 @@ github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69
 github.com/golang-jwt/jwt/v4 v4.0.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
 github.com/golang-jwt/jwt/v4 v4.2.0/go.mod h1:/xlHOz8bRuivTWchD4jCa+NbatV+wEUSzwAxVc6locg=
 github.com/golang-jwt/jwt/v4 v4.5.0/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
-github.com/golang-jwt/jwt/v4 v4.5.1 h1:JdqV9zKUdtaa9gdPlywC3aeoEsR681PlKC+4F5gQgeo=
-github.com/golang-jwt/jwt/v4 v4.5.1/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
+github.com/golang-jwt/jwt/v4 v4.5.2 h1:YtQM7lnr8iZ+j5q71MGKkNw9Mn7AjHM68uc9g5fXeUI=
+github.com/golang-jwt/jwt/v4 v4.5.2/go.mod h1:m21LjoU+eqJr34lmDMbreY2eSTRJ1cv77w39/MY0Ch0=
 github.com/golang-jwt/jwt/v5 v5.2.1 h1:OuVbFODueb089Lh128TAcimifWaLhJwVflnrgM17wHk=
 github.com/golang-jwt/jwt/v5 v5.2.1/go.mod h1:pqrtFR0X4osieyHYxtmOUWsAWrfe1Q5UVIyoH402zdk=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=


### PR DESCRIPTION
### Attaching scan report using trivy, grype (We cannot scan with Prisma, as image is not pushed to any registry as of now)

### Trivy

```
trivy image ko.local/github.com/kyverno/reports-server:fa6d240021ba556af2b779f8631e18c12aecd848d28f5082f5e3448d9168abb0
2025-03-26T09:07:07+05:30       INFO    [vuln] Vulnerability scanning is enabled
2025-03-26T09:07:07+05:30       INFO    [secret] Secret scanning is enabled
2025-03-26T09:07:07+05:30       INFO    [secret] If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2025-03-26T09:07:07+05:30       INFO    [secret] Please see also https://aquasecurity.github.io/trivy/v0.58/docs/scanner/secret#recommendation for faster secret detection
2025-03-26T09:07:07+05:30       INFO    Detected OS     family="wolfi" version="20230201"
2025-03-26T09:07:07+05:30       INFO    [wolfi] Detecting vulnerabilities...    pkg_num=3
2025-03-26T09:07:07+05:30       INFO    Number of language-specific files       num=1
2025-03-26T09:07:07+05:30       INFO    [gobinary] Detecting vulnerabilities...

ko.local/github.com/kyverno/reports-server:fa6d240021ba556af2b779f8631e18c12aecd848d28f5082f5e3448d9168abb0 (wolfi 20230201)

Total: 0 (UNKNOWN: 0, LOW: 0, MEDIUM: 0, HIGH: 0, CRITICAL: 0)


ko-app/reports-server (gobinary)

Total: 1 (UNKNOWN: 0, LOW: 0, MEDIUM: 1, HIGH: 0, CRITICAL: 0)

┌────────────────────────────┬────────────────┬──────────┬────────┬───────────────────┬────────────────┬────────────────────────────────────────────────┐
│          Library           │ Vulnerability  │ Severity │ Status │ Installed Version │ Fixed Version  │                     Title                      │
├────────────────────────────┼────────────────┼──────────┼────────┼───────────────────┼────────────────┼────────────────────────────────────────────────┤
│ github.com/kyverno/kyverno │ CVE-2025-29778 │ MEDIUM   │ fixed  │ v1.13.0           │ 1.14.0-alpha.1 │ Kyverno ignores subjectRegExp and IssuerRegExp │
│                            │                │          │        │                   │                │ https://avd.aquasec.com/nvd/cve-2025-29778     │
└────────────────────────────┴────────────────┴──────────┴────────┴───────────────────┴────────────────┴────────────────────────────────────────────────┘
```

### Grype

```
 grype ko.local/github.com/kyverno/reports-server:fa6d240021ba556af2b779f8631e18c12aecd848d28f5082f5e3448d9168abb0 
 ✔ Vulnerability DB                [no update available]  
 ✔ Loaded image                                                                                    ko.local/github.com/kyverno/reports-server:fa6d240021ba556af2b779f8631e18c12aecd848d28f5082f5e3448d9168abb0 
 ✔ Parsed image                                                                                                                        sha256:d21a939b206688b7aa0f366310cea535f245820f4701656da71a6d1cea36ce78 
 ✔ Cataloged contents                                                                                                                         95d17595a0e1c144d9358c415ca9c9929034d7a1f483e0727a0628d898e87401 
   ├── ✔ Packages                        [295 packages]  
   ├── ✔ File digests                    [703 files]  
   ├── ✔ File metadata                   [703 locations]  
   └── ✔ Executables                     [1 executables]  
 ✔ Scanned for vulnerabilities     [1 vulnerability matches]  
   ├── by severity: 0 critical, 0 high, 1 medium, 0 low, 0 negligible
   └── by status:   1 fixed, 0 not-fixed, 0 ignored 
NAME                        INSTALLED  FIXED-IN        TYPE       VULNERABILITY        SEVERITY 
github.com/kyverno/kyverno  v1.13.0    1.14.0-alpha.1  go-module  GHSA-46mp-8w32-6g94  Medium
```

We cannot fix the CVE's occurring due to OSS kyverno, as we are not supporting reports-server in full enterprise mode.