### PR TITLE
[NDEV-22428][NDEV-22388]: Tolerations and NodeSelector support for th…

### DIFF
--- a/charts/reports-server/README.md
+++ b/charts/reports-server/README.md
@@ -1,6 +1,6 @@
 # reports-server
 
-![Version: 0.1.16](https://img.shields.io/badge/Version-0.1.16-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 0.1.16](https://img.shields.io/badge/AppVersion-0.1.16-informational?style=flat-square)
+![Version: 0.1.17](https://img.shields.io/badge/Version-0.1.17-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.1.16](https://img.shields.io/badge/AppVersion-v0.1.16-informational?style=flat-square)
 
 TODO
 
@@ -73,6 +73,8 @@ helm install reports-server --namespace reports-server --create-namespace report
 | config.etcd.endpoints | string | `nil` |  |
 | config.etcd.insecure | bool | `true` |  |
 | config.etcd.storage | string | `nil` |  |
+| config.etcd.nodeSelector | object | `{}` |  |
+| config.etcd.tolerations | list | `[]` |  |
 | config.db.secretName | string | `""` | If set, database connection information will be read from the Secret with this name. Overrides `db.host`, `db.name`, `db.user`, and `db.password`. |
 | config.db.host | string | `"reports-server-cluster-rw.reports-server"` | Database host |
 | config.db.hostSecretKeyName | string | `"host"` | The database host will be read from this `key` in the specified Secret, when `db.secretName` is set. |

--- a/charts/reports-server/templates/etcd.yaml
+++ b/charts/reports-server/templates/etcd.yaml
@@ -46,6 +46,12 @@ spec:
       annotations:
         serviceName: etcd
     spec:
+{{- if .Values.config.etcd.nodeSelector }}
+      nodeSelector: {{ toYaml .Values.config.etcd.nodeSelector | nindent 8 }}
+{{- end }}
+{{- if .Values.config.etcd.tolerations }}
+      tolerations: {{ toYaml .Values.config.etcd.tolerations | nindent 8 }}
+{{- end }}
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/charts/reports-server/values.yaml
+++ b/charts/reports-server/values.yaml
@@ -192,6 +192,16 @@ config:
     # This value defines the size of the persistent volume claim (PVC) for etcd.
     storage:
 
+    ## @param nodeSelector [object] Node labels for pod assignment
+    ## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/
+    ##
+    nodeSelector: {}
+
+    ## @param tolerations [array] Tolerations for pod assignment
+    ## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+    ##
+    tolerations: []
+
   db:
     # -- If set, database connection information will be read from the Secret with this name. Overrides `db.host`, `db.name`, `db.user`, and `db.password`.
     secretName: ""

--- a/config/install-etcd.yaml
+++ b/config/install-etcd.yaml
@@ -10,10 +10,10 @@ metadata:
   name: reports-server
   namespace: reports-server
   labels:
-    helm.sh/chart: reports-server-0.1.16
+    helm.sh/chart: reports-server-0.1.17
     app.kubernetes.io/name: reports-server
     app.kubernetes.io/instance: reports-server
-    app.kubernetes.io/version: "0.1.16"
+    app.kubernetes.io/version: "v0.1.16"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -27,10 +27,10 @@ metadata:
   name: reports-server
   namespace: reports-server
   labels:
-    helm.sh/chart: reports-server-0.1.16
+    helm.sh/chart: reports-server-0.1.17
     app.kubernetes.io/name: reports-server
     app.kubernetes.io/instance: reports-server
-    app.kubernetes.io/version: "0.1.16"
+    app.kubernetes.io/version: "v0.1.16"
     app.kubernetes.io/managed-by: Helm
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -41,10 +41,10 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-admin: 'true'
     rbac.authorization.k8s.io/aggregate-to-edit: 'true'
     rbac.authorization.k8s.io/aggregate-to-view: 'true'
-    helm.sh/chart: reports-server-0.1.16
+    helm.sh/chart: reports-server-0.1.17
     app.kubernetes.io/name: reports-server
     app.kubernetes.io/instance: reports-server
-    app.kubernetes.io/version: "0.1.16"
+    app.kubernetes.io/version: "v0.1.16"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -128,10 +128,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: reports-server
   labels:
-    helm.sh/chart: reports-server-0.1.16
+    helm.sh/chart: reports-server-0.1.17
     app.kubernetes.io/name: reports-server
     app.kubernetes.io/instance: reports-server
-    app.kubernetes.io/version: "0.1.16"
+    app.kubernetes.io/version: "v0.1.16"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -148,10 +148,10 @@ metadata:
   name: reports-server
   namespace: reports-server
   labels:
-    helm.sh/chart: reports-server-0.1.16
+    helm.sh/chart: reports-server-0.1.17
     app.kubernetes.io/name: reports-server
     app.kubernetes.io/instance: reports-server
-    app.kubernetes.io/version: "0.1.16"
+    app.kubernetes.io/version: "v0.1.16"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -168,10 +168,10 @@ metadata:
   name: reports-server
   namespace: kube-system
   labels:
-    helm.sh/chart: reports-server-0.1.16
+    helm.sh/chart: reports-server-0.1.17
     app.kubernetes.io/name: reports-server
     app.kubernetes.io/instance: reports-server
-    app.kubernetes.io/version: "0.1.16"
+    app.kubernetes.io/version: "v0.1.16"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -188,10 +188,10 @@ metadata:
   name: reports-server
   namespace: reports-server
   labels:
-    helm.sh/chart: reports-server-0.1.16
+    helm.sh/chart: reports-server-0.1.17
     app.kubernetes.io/name: reports-server
     app.kubernetes.io/instance: reports-server
-    app.kubernetes.io/version: "0.1.16"
+    app.kubernetes.io/version: "v0.1.16"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -209,10 +209,10 @@ metadata:
   namespace: reports-server
   labels:
     app: etcd-reports-server
-    helm.sh/chart: reports-server-0.1.16
+    helm.sh/chart: reports-server-0.1.17
     app.kubernetes.io/name: reports-server
     app.kubernetes.io/instance: reports-server
-    app.kubernetes.io/version: "0.1.16"
+    app.kubernetes.io/version: "v0.1.16"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -234,10 +234,10 @@ metadata:
   name: reports-server
   namespace: reports-server
   labels:
-    helm.sh/chart: reports-server-0.1.16
+    helm.sh/chart: reports-server-0.1.17
     app.kubernetes.io/name: reports-server
     app.kubernetes.io/instance: reports-server
-    app.kubernetes.io/version: "0.1.16"
+    app.kubernetes.io/version: "v0.1.16"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -256,10 +256,10 @@ metadata:
   name: reports-server
   namespace: reports-server
   labels:
-    helm.sh/chart: reports-server-0.1.16
+    helm.sh/chart: reports-server-0.1.17
     app.kubernetes.io/name: reports-server
     app.kubernetes.io/instance: reports-server
-    app.kubernetes.io/version: "0.1.16"
+    app.kubernetes.io/version: "v0.1.16"
     app.kubernetes.io/managed-by: Helm
 spec:
   strategy:
@@ -273,10 +273,10 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: reports-server-0.1.16
+        helm.sh/chart: reports-server-0.1.17
         app.kubernetes.io/name: reports-server
         app.kubernetes.io/instance: reports-server
-        app.kubernetes.io/version: "0.1.16"
+        app.kubernetes.io/version: "v0.1.16"
         app.kubernetes.io/managed-by: Helm
     spec:
       priorityClassName: system-cluster-critical
@@ -358,10 +358,10 @@ metadata:
   name: etcd
   labels:
     app: etcd-reports-server
-    helm.sh/chart: reports-server-0.1.16
+    helm.sh/chart: reports-server-0.1.17
     app.kubernetes.io/name: reports-server
     app.kubernetes.io/instance: reports-server
-    app.kubernetes.io/version: "0.1.16"
+    app.kubernetes.io/version: "v0.1.16"
     app.kubernetes.io/managed-by: Helm
 spec:
   serviceName: etcd
@@ -506,10 +506,10 @@ metadata:
   name: v1alpha2.wgpolicyk8s.io
   namespace: reports-server
   labels:
-    helm.sh/chart: reports-server-0.1.16
+    helm.sh/chart: reports-server-0.1.17
     app.kubernetes.io/name: reports-server
     app.kubernetes.io/instance: reports-server
-    app.kubernetes.io/version: "0.1.16"
+    app.kubernetes.io/version: "v0.1.16"
     app.kubernetes.io/managed-by: Helm
     kube-aggregator.kubernetes.io/automanaged: "false"
   annotations:
@@ -530,10 +530,10 @@ metadata:
   name: v1.reports.kyverno.io
   namespace: reports-server
   labels:
-    helm.sh/chart: reports-server-0.1.16
+    helm.sh/chart: reports-server-0.1.17
     app.kubernetes.io/name: reports-server
     app.kubernetes.io/instance: reports-server
-    app.kubernetes.io/version: "0.1.16"
+    app.kubernetes.io/version: "v0.1.16"
     app.kubernetes.io/managed-by: Helm
     kube-aggregator.kubernetes.io/automanaged: "false"
   annotations:

--- a/config/install.yaml
+++ b/config/install.yaml
@@ -10,10 +10,10 @@ metadata:
   name: reports-server
   namespace: reports-server
   labels:
-    helm.sh/chart: reports-server-0.1.16
+    helm.sh/chart: reports-server-0.1.17
     app.kubernetes.io/name: reports-server
     app.kubernetes.io/instance: reports-server
-    app.kubernetes.io/version: "0.1.16"
+    app.kubernetes.io/version: "v0.1.16"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -27,10 +27,10 @@ metadata:
   name: reports-server
   namespace: reports-server
   labels:
-    helm.sh/chart: reports-server-0.1.16
+    helm.sh/chart: reports-server-0.1.17
     app.kubernetes.io/name: reports-server
     app.kubernetes.io/instance: reports-server
-    app.kubernetes.io/version: "0.1.16"
+    app.kubernetes.io/version: "v0.1.16"
     app.kubernetes.io/managed-by: Helm
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -41,10 +41,10 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-admin: 'true'
     rbac.authorization.k8s.io/aggregate-to-edit: 'true'
     rbac.authorization.k8s.io/aggregate-to-view: 'true'
-    helm.sh/chart: reports-server-0.1.16
+    helm.sh/chart: reports-server-0.1.17
     app.kubernetes.io/name: reports-server
     app.kubernetes.io/instance: reports-server
-    app.kubernetes.io/version: "0.1.16"
+    app.kubernetes.io/version: "v0.1.16"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -128,10 +128,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: reports-server
   labels:
-    helm.sh/chart: reports-server-0.1.16
+    helm.sh/chart: reports-server-0.1.17
     app.kubernetes.io/name: reports-server
     app.kubernetes.io/instance: reports-server
-    app.kubernetes.io/version: "0.1.16"
+    app.kubernetes.io/version: "v0.1.16"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -148,10 +148,10 @@ metadata:
   name: reports-server
   namespace: reports-server
   labels:
-    helm.sh/chart: reports-server-0.1.16
+    helm.sh/chart: reports-server-0.1.17
     app.kubernetes.io/name: reports-server
     app.kubernetes.io/instance: reports-server
-    app.kubernetes.io/version: "0.1.16"
+    app.kubernetes.io/version: "v0.1.16"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -168,10 +168,10 @@ metadata:
   name: reports-server
   namespace: kube-system
   labels:
-    helm.sh/chart: reports-server-0.1.16
+    helm.sh/chart: reports-server-0.1.17
     app.kubernetes.io/name: reports-server
     app.kubernetes.io/instance: reports-server
-    app.kubernetes.io/version: "0.1.16"
+    app.kubernetes.io/version: "v0.1.16"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -188,10 +188,10 @@ metadata:
   name: reports-server
   namespace: reports-server
   labels:
-    helm.sh/chart: reports-server-0.1.16
+    helm.sh/chart: reports-server-0.1.17
     app.kubernetes.io/name: reports-server
     app.kubernetes.io/instance: reports-server
-    app.kubernetes.io/version: "0.1.16"
+    app.kubernetes.io/version: "v0.1.16"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -209,10 +209,10 @@ metadata:
   namespace: reports-server
   labels:
     app: etcd-reports-server
-    helm.sh/chart: reports-server-0.1.16
+    helm.sh/chart: reports-server-0.1.17
     app.kubernetes.io/name: reports-server
     app.kubernetes.io/instance: reports-server
-    app.kubernetes.io/version: "0.1.16"
+    app.kubernetes.io/version: "v0.1.16"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -234,10 +234,10 @@ metadata:
   name: reports-server
   namespace: reports-server
   labels:
-    helm.sh/chart: reports-server-0.1.16
+    helm.sh/chart: reports-server-0.1.17
     app.kubernetes.io/name: reports-server
     app.kubernetes.io/instance: reports-server
-    app.kubernetes.io/version: "0.1.16"
+    app.kubernetes.io/version: "v0.1.16"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -256,10 +256,10 @@ metadata:
   name: reports-server
   namespace: reports-server
   labels:
-    helm.sh/chart: reports-server-0.1.16
+    helm.sh/chart: reports-server-0.1.17
     app.kubernetes.io/name: reports-server
     app.kubernetes.io/instance: reports-server
-    app.kubernetes.io/version: "0.1.16"
+    app.kubernetes.io/version: "v0.1.16"
     app.kubernetes.io/managed-by: Helm
 spec:
   strategy:
@@ -273,10 +273,10 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: reports-server-0.1.16
+        helm.sh/chart: reports-server-0.1.17
         app.kubernetes.io/name: reports-server
         app.kubernetes.io/instance: reports-server
-        app.kubernetes.io/version: "0.1.16"
+        app.kubernetes.io/version: "v0.1.16"
         app.kubernetes.io/managed-by: Helm
     spec:
       priorityClassName: system-cluster-critical
@@ -358,10 +358,10 @@ metadata:
   name: etcd
   labels:
     app: etcd-reports-server
-    helm.sh/chart: reports-server-0.1.16
+    helm.sh/chart: reports-server-0.1.17
     app.kubernetes.io/name: reports-server
     app.kubernetes.io/instance: reports-server
-    app.kubernetes.io/version: "0.1.16"
+    app.kubernetes.io/version: "v0.1.16"
     app.kubernetes.io/managed-by: Helm
 spec:
   serviceName: etcd
@@ -506,10 +506,10 @@ metadata:
   name: v1alpha2.wgpolicyk8s.io
   namespace: reports-server
   labels:
-    helm.sh/chart: reports-server-0.1.16
+    helm.sh/chart: reports-server-0.1.17
     app.kubernetes.io/name: reports-server
     app.kubernetes.io/instance: reports-server
-    app.kubernetes.io/version: "0.1.16"
+    app.kubernetes.io/version: "v0.1.16"
     app.kubernetes.io/managed-by: Helm
     kube-aggregator.kubernetes.io/automanaged: "false"
   annotations:
@@ -530,10 +530,10 @@ metadata:
   name: v1.reports.kyverno.io
   namespace: reports-server
   labels:
-    helm.sh/chart: reports-server-0.1.16
+    helm.sh/chart: reports-server-0.1.17
     app.kubernetes.io/name: reports-server
     app.kubernetes.io/instance: reports-server
-    app.kubernetes.io/version: "0.1.16"
+    app.kubernetes.io/version: "v0.1.16"
     app.kubernetes.io/managed-by: Helm
     kube-aggregator.kubernetes.io/automanaged: "false"
   annotations:

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/kyverno/reports-server
 go 1.23.6
 
 require (
+	github.com/jackc/pgx/v5 v5.7.4
 	github.com/kyverno/kyverno v1.13.0
-	github.com/lib/pq v1.10.9
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.8.1
 	go.etcd.io/etcd/client/v3 v3.5.16
@@ -164,7 +164,6 @@ require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
-	github.com/jackc/pgx/v5 v5.7.4 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
 	github.com/jedisct1/go-minisign v0.0.0-20230811132847-661be99b8267 // indirect
 	github.com/jinzhu/copier v0.4.0 // indirect

--- a/pkg/storage/db/new.go
+++ b/pkg/storage/db/new.go
@@ -123,7 +123,6 @@ type PostgresConfig struct {
 }
 
 func (p PostgresConfig) String() string {
-
 	if p.Port != 0 {
 		hosts := strings.Split(p.Host, ",")
 		for i, host := range hosts {


### PR DESCRIPTION
…e etcd (#82)

* node selector and tolerations added in the config values.yaml

* nodeSelector and tolerations added in the etcd.yaml spec

* fixed the position of the nodeSelector and tolerations

* codegen executed

* make codegen executed

* golangci-lint fixed

* codegen generated again

* removing all workflows apart from lint and codegen

* codegen executed using the docker run --rm -v "$(pwd)":/workspace -w /workspace jnorwood/helm-docs:v1.11.0 make codegen

* workflow changed to see what exectly is the difference getting committed

* fixing the verify codegen workflow

* chore: update generated code

* Revert "removing all workflows apart from lint and codegen"

This reverts commit f2ce1a393e6a9ea4e8ca51ed2595757d5cf7c1f7.

* pinned down the action version of setup-go and checkout

* golangci-lint fix executed

* make codegen executed via local

* chore: update generated code

* fix codegen

* change workflow

* removing all workflows to isolate the issue

* make codegen executed via the docker file

* cloning kyverno into  GOPATH_SHIM so openapi-gen can find its API packages

* forcing verify codegen to read from the GOPATH

* ordering of jobs changed so tools can be downloaded

* removing shim logic

* goModule mode turned on in the verify codegen stage

* tools excluded from gitignore and pushed into the repo

* install codegen commented

* vendor based solution implemented to fix the verify-codegen

* worflow given private access to repo

* PAT used to check the workflows and the makefile

* verify codegen reverted back to the working module

* makefile changed to have the exact upstream makefile

* fixed typo in the makefile

* makefile copied from the OSS

* tools deleted and ignored from codegen

* removing the dependency from n4k and getting dependency on the kyverno/kyverno

* go mod executed

* makefile and codegen adjusted as per the public dependenice

* Revert "makefile and codegen adjusted as per the public dependenice"

This reverts commit 79787094b11599eae860f57fb486a8dade31d3cf.

* adding dependency back to the enterprise kyverno

* go mod tidy executed

* go private support added in the makefile

* Revert "removing all workflows to isolate the issue"

This reverts commit 65fbf7464d2e9255b44e502735bf4119c29848a3.

* codegen workflow reverted

---------