### PR TITLE
Reports server replica db fix (#97)

### DIFF
--- a/charts/reports-server/README.md
+++ b/charts/reports-server/README.md
@@ -1,6 +1,6 @@
 # reports-server
 
-![Version: 0.1.19](https://img.shields.io/badge/Version-0.1.19-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.1.17](https://img.shields.io/badge/AppVersion-v0.1.17-informational?style=flat-square)
+![Version: 0.1.20](https://img.shields.io/badge/Version-0.1.20-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.1.18](https://img.shields.io/badge/AppVersion-v0.1.18-informational?style=flat-square)
 
 TODO
 

--- a/config/install-etcd.yaml
+++ b/config/install-etcd.yaml
@@ -10,10 +10,10 @@ metadata:
   name: reports-server
   namespace: reports-server
   labels:
-    helm.sh/chart: reports-server-0.1.19
+    helm.sh/chart: reports-server-0.1.20
     app.kubernetes.io/name: reports-server
     app.kubernetes.io/instance: reports-server
-    app.kubernetes.io/version: "v0.1.17"
+    app.kubernetes.io/version: "v0.1.18"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -27,10 +27,10 @@ metadata:
   name: reports-server
   namespace: reports-server
   labels:
-    helm.sh/chart: reports-server-0.1.19
+    helm.sh/chart: reports-server-0.1.20
     app.kubernetes.io/name: reports-server
     app.kubernetes.io/instance: reports-server
-    app.kubernetes.io/version: "v0.1.17"
+    app.kubernetes.io/version: "v0.1.18"
     app.kubernetes.io/managed-by: Helm
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -41,10 +41,10 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-admin: 'true'
     rbac.authorization.k8s.io/aggregate-to-edit: 'true'
     rbac.authorization.k8s.io/aggregate-to-view: 'true'
-    helm.sh/chart: reports-server-0.1.19
+    helm.sh/chart: reports-server-0.1.20
     app.kubernetes.io/name: reports-server
     app.kubernetes.io/instance: reports-server
-    app.kubernetes.io/version: "v0.1.17"
+    app.kubernetes.io/version: "v0.1.18"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -128,10 +128,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: reports-server
   labels:
-    helm.sh/chart: reports-server-0.1.19
+    helm.sh/chart: reports-server-0.1.20
     app.kubernetes.io/name: reports-server
     app.kubernetes.io/instance: reports-server
-    app.kubernetes.io/version: "v0.1.17"
+    app.kubernetes.io/version: "v0.1.18"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -148,10 +148,10 @@ metadata:
   name: reports-server
   namespace: reports-server
   labels:
-    helm.sh/chart: reports-server-0.1.19
+    helm.sh/chart: reports-server-0.1.20
     app.kubernetes.io/name: reports-server
     app.kubernetes.io/instance: reports-server
-    app.kubernetes.io/version: "v0.1.17"
+    app.kubernetes.io/version: "v0.1.18"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -168,10 +168,10 @@ metadata:
   name: reports-server
   namespace: kube-system
   labels:
-    helm.sh/chart: reports-server-0.1.19
+    helm.sh/chart: reports-server-0.1.20
     app.kubernetes.io/name: reports-server
     app.kubernetes.io/instance: reports-server
-    app.kubernetes.io/version: "v0.1.17"
+    app.kubernetes.io/version: "v0.1.18"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -188,10 +188,10 @@ metadata:
   name: reports-server
   namespace: reports-server
   labels:
-    helm.sh/chart: reports-server-0.1.19
+    helm.sh/chart: reports-server-0.1.20
     app.kubernetes.io/name: reports-server
     app.kubernetes.io/instance: reports-server
-    app.kubernetes.io/version: "v0.1.17"
+    app.kubernetes.io/version: "v0.1.18"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -209,10 +209,10 @@ metadata:
   namespace: reports-server
   labels:
     app: etcd-reports-server
-    helm.sh/chart: reports-server-0.1.19
+    helm.sh/chart: reports-server-0.1.20
     app.kubernetes.io/name: reports-server
     app.kubernetes.io/instance: reports-server
-    app.kubernetes.io/version: "v0.1.17"
+    app.kubernetes.io/version: "v0.1.18"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -234,10 +234,10 @@ metadata:
   name: reports-server
   namespace: reports-server
   labels:
-    helm.sh/chart: reports-server-0.1.19
+    helm.sh/chart: reports-server-0.1.20
     app.kubernetes.io/name: reports-server
     app.kubernetes.io/instance: reports-server
-    app.kubernetes.io/version: "v0.1.17"
+    app.kubernetes.io/version: "v0.1.18"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -256,10 +256,10 @@ metadata:
   name: reports-server
   namespace: reports-server
   labels:
-    helm.sh/chart: reports-server-0.1.19
+    helm.sh/chart: reports-server-0.1.20
     app.kubernetes.io/name: reports-server
     app.kubernetes.io/instance: reports-server
-    app.kubernetes.io/version: "v0.1.17"
+    app.kubernetes.io/version: "v0.1.18"
     app.kubernetes.io/managed-by: Helm
 spec:
   strategy:
@@ -273,10 +273,10 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: reports-server-0.1.19
+        helm.sh/chart: reports-server-0.1.20
         app.kubernetes.io/name: reports-server
         app.kubernetes.io/instance: reports-server
-        app.kubernetes.io/version: "v0.1.17"
+        app.kubernetes.io/version: "v0.1.18"
         app.kubernetes.io/managed-by: Helm
     spec:
       priorityClassName: system-cluster-critical
@@ -360,10 +360,10 @@ metadata:
   name: etcd
   labels:
     app: etcd-reports-server
-    helm.sh/chart: reports-server-0.1.19
+    helm.sh/chart: reports-server-0.1.20
     app.kubernetes.io/name: reports-server
     app.kubernetes.io/instance: reports-server
-    app.kubernetes.io/version: "v0.1.17"
+    app.kubernetes.io/version: "v0.1.18"
     app.kubernetes.io/managed-by: Helm
 spec:
   serviceName: etcd
@@ -509,10 +509,10 @@ metadata:
   name: v1alpha2.wgpolicyk8s.io
   namespace: reports-server
   labels:
-    helm.sh/chart: reports-server-0.1.19
+    helm.sh/chart: reports-server-0.1.20
     app.kubernetes.io/name: reports-server
     app.kubernetes.io/instance: reports-server
-    app.kubernetes.io/version: "v0.1.17"
+    app.kubernetes.io/version: "v0.1.18"
     app.kubernetes.io/managed-by: Helm
     kube-aggregator.kubernetes.io/automanaged: "false"
   annotations:
@@ -533,10 +533,10 @@ metadata:
   name: v1.reports.kyverno.io
   namespace: reports-server
   labels:
-    helm.sh/chart: reports-server-0.1.19
+    helm.sh/chart: reports-server-0.1.20
     app.kubernetes.io/name: reports-server
     app.kubernetes.io/instance: reports-server
-    app.kubernetes.io/version: "v0.1.17"
+    app.kubernetes.io/version: "v0.1.18"
     app.kubernetes.io/managed-by: Helm
     kube-aggregator.kubernetes.io/automanaged: "false"
   annotations:

--- a/config/install.yaml
+++ b/config/install.yaml
@@ -10,10 +10,10 @@ metadata:
   name: reports-server
   namespace: reports-server
   labels:
-    helm.sh/chart: reports-server-0.1.19
+    helm.sh/chart: reports-server-0.1.20
     app.kubernetes.io/name: reports-server
     app.kubernetes.io/instance: reports-server
-    app.kubernetes.io/version: "v0.1.17"
+    app.kubernetes.io/version: "v0.1.18"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -27,10 +27,10 @@ metadata:
   name: reports-server
   namespace: reports-server
   labels:
-    helm.sh/chart: reports-server-0.1.19
+    helm.sh/chart: reports-server-0.1.20
     app.kubernetes.io/name: reports-server
     app.kubernetes.io/instance: reports-server
-    app.kubernetes.io/version: "v0.1.17"
+    app.kubernetes.io/version: "v0.1.18"
     app.kubernetes.io/managed-by: Helm
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -41,10 +41,10 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-admin: 'true'
     rbac.authorization.k8s.io/aggregate-to-edit: 'true'
     rbac.authorization.k8s.io/aggregate-to-view: 'true'
-    helm.sh/chart: reports-server-0.1.19
+    helm.sh/chart: reports-server-0.1.20
     app.kubernetes.io/name: reports-server
     app.kubernetes.io/instance: reports-server
-    app.kubernetes.io/version: "v0.1.17"
+    app.kubernetes.io/version: "v0.1.18"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -128,10 +128,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: reports-server
   labels:
-    helm.sh/chart: reports-server-0.1.19
+    helm.sh/chart: reports-server-0.1.20
     app.kubernetes.io/name: reports-server
     app.kubernetes.io/instance: reports-server
-    app.kubernetes.io/version: "v0.1.17"
+    app.kubernetes.io/version: "v0.1.18"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -148,10 +148,10 @@ metadata:
   name: reports-server
   namespace: reports-server
   labels:
-    helm.sh/chart: reports-server-0.1.19
+    helm.sh/chart: reports-server-0.1.20
     app.kubernetes.io/name: reports-server
     app.kubernetes.io/instance: reports-server
-    app.kubernetes.io/version: "v0.1.17"
+    app.kubernetes.io/version: "v0.1.18"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -168,10 +168,10 @@ metadata:
   name: reports-server
   namespace: kube-system
   labels:
-    helm.sh/chart: reports-server-0.1.19
+    helm.sh/chart: reports-server-0.1.20
     app.kubernetes.io/name: reports-server
     app.kubernetes.io/instance: reports-server
-    app.kubernetes.io/version: "v0.1.17"
+    app.kubernetes.io/version: "v0.1.18"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -188,10 +188,10 @@ metadata:
   name: reports-server
   namespace: reports-server
   labels:
-    helm.sh/chart: reports-server-0.1.19
+    helm.sh/chart: reports-server-0.1.20
     app.kubernetes.io/name: reports-server
     app.kubernetes.io/instance: reports-server
-    app.kubernetes.io/version: "v0.1.17"
+    app.kubernetes.io/version: "v0.1.18"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -209,10 +209,10 @@ metadata:
   namespace: reports-server
   labels:
     app: etcd-reports-server
-    helm.sh/chart: reports-server-0.1.19
+    helm.sh/chart: reports-server-0.1.20
     app.kubernetes.io/name: reports-server
     app.kubernetes.io/instance: reports-server
-    app.kubernetes.io/version: "v0.1.17"
+    app.kubernetes.io/version: "v0.1.18"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -234,10 +234,10 @@ metadata:
   name: reports-server
   namespace: reports-server
   labels:
-    helm.sh/chart: reports-server-0.1.19
+    helm.sh/chart: reports-server-0.1.20
     app.kubernetes.io/name: reports-server
     app.kubernetes.io/instance: reports-server
-    app.kubernetes.io/version: "v0.1.17"
+    app.kubernetes.io/version: "v0.1.18"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -256,10 +256,10 @@ metadata:
   name: reports-server
   namespace: reports-server
   labels:
-    helm.sh/chart: reports-server-0.1.19
+    helm.sh/chart: reports-server-0.1.20
     app.kubernetes.io/name: reports-server
     app.kubernetes.io/instance: reports-server
-    app.kubernetes.io/version: "v0.1.17"
+    app.kubernetes.io/version: "v0.1.18"
     app.kubernetes.io/managed-by: Helm
 spec:
   strategy:
@@ -273,10 +273,10 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: reports-server-0.1.19
+        helm.sh/chart: reports-server-0.1.20
         app.kubernetes.io/name: reports-server
         app.kubernetes.io/instance: reports-server
-        app.kubernetes.io/version: "v0.1.17"
+        app.kubernetes.io/version: "v0.1.18"
         app.kubernetes.io/managed-by: Helm
     spec:
       priorityClassName: system-cluster-critical
@@ -360,10 +360,10 @@ metadata:
   name: etcd
   labels:
     app: etcd-reports-server
-    helm.sh/chart: reports-server-0.1.19
+    helm.sh/chart: reports-server-0.1.20
     app.kubernetes.io/name: reports-server
     app.kubernetes.io/instance: reports-server
-    app.kubernetes.io/version: "v0.1.17"
+    app.kubernetes.io/version: "v0.1.18"
     app.kubernetes.io/managed-by: Helm
 spec:
   serviceName: etcd
@@ -509,10 +509,10 @@ metadata:
   name: v1alpha2.wgpolicyk8s.io
   namespace: reports-server
   labels:
-    helm.sh/chart: reports-server-0.1.19
+    helm.sh/chart: reports-server-0.1.20
     app.kubernetes.io/name: reports-server
     app.kubernetes.io/instance: reports-server
-    app.kubernetes.io/version: "v0.1.17"
+    app.kubernetes.io/version: "v0.1.18"
     app.kubernetes.io/managed-by: Helm
     kube-aggregator.kubernetes.io/automanaged: "false"
   annotations:
@@ -533,10 +533,10 @@ metadata:
   name: v1.reports.kyverno.io
   namespace: reports-server
   labels:
-    helm.sh/chart: reports-server-0.1.19
+    helm.sh/chart: reports-server-0.1.20
     app.kubernetes.io/name: reports-server
     app.kubernetes.io/instance: reports-server
-    app.kubernetes.io/version: "v0.1.17"
+    app.kubernetes.io/version: "v0.1.18"
     app.kubernetes.io/managed-by: Helm
     kube-aggregator.kubernetes.io/automanaged: "false"
   annotations:

--- a/pkg/storage/db/new.go
+++ b/pkg/storage/db/new.go
@@ -33,6 +33,9 @@ func New(config *PostgresConfig, clusterId string) (api.Storage, error) {
 
 	var readReplicas []*sql.DB
 	for _, host := range config.ReadReplicaHosts {
+		if host == "" {
+			continue
+		}
 		replicaCfg := *config
 		replicaCfg.Host = host
 		dsn := replicaCfg.String()


### PR DESCRIPTION
* [NDEV-22428][NDEV-22388]: Tolerations and NodeSelector support for the etcd (#82) (#86)

* node selector and tolerations added in the config values.yaml

* nodeSelector and tolerations added in the etcd.yaml spec

* fixed the position of the nodeSelector and tolerations

* codegen executed

* make codegen executed

* golangci-lint fixed

* codegen generated again

* removing all workflows apart from lint and codegen

* codegen executed using the docker run --rm -v "$(pwd)":/workspace -w /workspace jnorwood/helm-docs:v1.11.0 make codegen

* workflow changed to see what exectly is the difference getting committed

* fixing the verify codegen workflow

* chore: update generated code

* Revert "removing all workflows apart from lint and codegen"

This reverts commit f2ce1a393e6a9ea4e8ca51ed2595757d5cf7c1f7.

* pinned down the action version of setup-go and checkout

* golangci-lint fix executed

* make codegen executed via local

* chore: update generated code

* fix codegen

* change workflow

* removing all workflows to isolate the issue

* make codegen executed via the docker file

* cloning kyverno into  GOPATH_SHIM so openapi-gen can find its API packages

* forcing verify codegen to read from the GOPATH

* ordering of jobs changed so tools can be downloaded

* removing shim logic

* goModule mode turned on in the verify codegen stage

* tools excluded from gitignore and pushed into the repo

* install codegen commented

* vendor based solution implemented to fix the verify-codegen

* worflow given private access to repo

* PAT used to check the workflows and the makefile

* verify codegen reverted back to the working module

* makefile changed to have the exact upstream makefile

* fixed typo in the makefile

* makefile copied from the OSS

* tools deleted and ignored from codegen

* removing the dependency from n4k and getting dependency on the kyverno/kyverno

* go mod executed

* makefile and codegen adjusted as per the public dependenice

* Revert "makefile and codegen adjusted as per the public dependenice"

This reverts commit 79787094b11599eae860f57fb486a8dade31d3cf.

* adding dependency back to the enterprise kyverno

* go mod tidy executed

* go private support added in the makefile

* Revert "removing all workflows to isolate the issue"

This reverts commit 65fbf7464d2e9255b44e502735bf4119c29848a3.

* codegen workflow reverted

---------





* Cherry pick 89 (#91)

* add quota limit and secret configuration for custom ssl (#89)

* add quota limit and secret configuration for custom ssl

* add comment for debug

* fixing the issue with formatting the integer in argument to forcefully print integer in integeric form

* update default value

* make codegen executed

* update documentation

* make codegen executed

* update documentation

---------



* make codegen executed

---------



* NDEV-22493: fix: handle PostgreSQL database connection when password contains special characters (#90) (#92)

* fix: encode string to handle special chars in username and password

* test: add unit and integrations tests for connecting to db with special chars

* gomod changes

---------



* Chart version bump 0.1.18 (#93)

* chart version bumped to 0.1.18

* appVersion bumped to 0.1.17

* make codegen executed

* Cherry pick  #94 (#95)

* make codegen executed and merge conflict resolution

* make codegen executed

* Cherry pick #88 rls 0.1 (#96)

* [NDEV-22437]:  replica DB support in the reports server (#88)

* gitignore updated to ignore .DS_store files

* DBReadReplicaHosts introduced in the options

* read replicas hosts introduced in the postgres config

* readReplicaHosts passed in the db config

* populated the value of the db replica hosts in the config

* introduced the primaryDB and the readReplicaDBs in the struct and the constructor

* parameter renamed from DB to primaryDB

* readQuery function added

* integrated the readQuery function instead of explicit primaryDB query

* readQuery function integrated in the Get clusterephemeralreports function

* struct and constructor changed to support the readReplicaDB

* ReadQuery function introduced in the cpolr

* closing rows after the error check

* readQuery function integrated in the clusterpolicyreports

* ReadQuery function introduced in the ephrdb along with changing structure and the constructor

* readQuery function incorporated in the List

* ReadQuery introduced in the Get function

* struct and constructor changed of polrdb to accomodate the readReplicaDBs

* ReadQuery integrated in the List functionality of polrdb

* readQuery incorporated in the Get function of the polrdb

* random shuffling of the readReplicas before executing the query

* fixing issue with the primaryDB arguments

* replacing math/rand/v2 with math/rand

* locking and unlock only during the replica copy

* seeding added for the randomization

* readQueryRow function introduced to support the get calls of the models

* removing nested locking and unlocking

* new.go driver function call incorporated the read replicas

* readReplicaHosts added in the values.yaml of the reports-server chart

* db_read_replica_hosts added in the deployment.yaml template

* multiDB structure introduced

* multiDB structure incorporated

* multiDB structure incorporated

* added the readQuery method in the storage db

* incorporated multiDB name in the cpolrDB

* file renamed and typo fixed

* readQueryRow fixed in the multiDB

* multiDB injected in the cpolr

* multiDB used in all the store functions

* MultiDB added in the cephr struct and constructor, removed the read and readQueryrow method

* multiDB incorporated in the cephr store functions

* MultiDB added in the ephr struct and constructor, removed the read and readQueryrow method

* multiDB incorporated in the ephr store functions

* MultiDB added in the polr struct and constructor, removed the read and readQueryrow method

* multiDB incorporated in the polr store functions

* multiDB injected in the stores

* Makefile added for the debugging command

* readReplicaHosts and readReplicaHostsSecretKeyName added in the values.yaml

* chart version bumped to 0.1.18-rc1

* readReplicaHosts added in the helpers.tpl

* logging added in the cpolr

* logging added in the cpolr

* loggingss added for all the files in the storage dn

* Revert "loggingss added for all the files in the storage dn"

This reverts commit b286f975bf3c6fd1494dda608dcfe90406c4404a.

* Revert "logging added in the cpolr"

This reverts commit c38f124ff4602e580413449fc47bbc8cf39d4e79.

* Revert "logging added in the cpolr"

This reverts commit 6b0a80d9bb9599a0d4fd6ce316022bb2e1a3baf0.

* make codegen executed

* implemented Fisher–Yates shuffle to shuffle read replicas

* makefile changes removed

* unit test cases added for the all stores

* go modules added for sql mocking

* test cases removed as too difficult to manage with existing coding pattern

* make codegen executed

* chart version bumped to 0.1.18-rc.2

* make codegen command executed

* string method changes reverted back

* make codegen executed

* app version and version bumped

* go mod tidy executed

* fix script failure after timeout

---------



* chart version bumped to 0.1.20 and the app version upgraded to 0.1.18

* if host is empty skip the connection

---------

[NDEV-22428]: https://nirmata.atlassian.net/browse/NDEV-22428?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[NDEV-22437]: https://nirmata.atlassian.net/browse/NDEV-22437?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ