### PR TITLE
[NDEV-23163]: making etcd image and registry configurable

### DIFF
--- a/charts/reports-server/Chart.yaml
+++ b/charts/reports-server/Chart.yaml
@@ -1,8 +1,8 @@
 apiVersion: v2
 name: reports-server
 type: application
-version: 0.1.20
-appVersion: v0.1.18
+version: 0.1.22
+appVersion: v0.1.19
 keywords:
 - kubernetes
 - policy reports storage

--- a/charts/reports-server/README.md
+++ b/charts/reports-server/README.md
@@ -69,6 +69,9 @@ helm install reports-server --namespace reports-server --create-namespace report
 | affinity | object | `{}` | Affinity |
 | service.type | string | `"ClusterIP"` | Service type |
 | service.port | int | `443` | Service port |
+| config.etcd.image.registry | string | `"ghcr.io"` |  |
+| config.etcd.image.repository | string | `"nirmata/etcd"` |  |
+| config.etcd.image.tag | string | `"v3.5.18-cve-free"` |  |
 | config.etcd.enabled | bool | `true` |  |
 | config.etcd.endpoints | string | `nil` |  |
 | config.etcd.insecure | bool | `true` |  |
@@ -79,7 +82,7 @@ helm install reports-server --namespace reports-server --create-namespace report
 | config.db.secretName | string | `""` | If set, database connection information will be read from the Secret with this name. Overrides `db.host`, `db.name`, `db.user`, `db.password` and `db.readReplicaHosts`. |
 | config.db.host | string | `"reports-server-cluster-rw.reports-server"` | Database host |
 | config.db.hostSecretKeyName | string | `"host"` | The database host will be read from this `key` in the specified Secret, when `db.secretName` is set. |
-| config.db.readReplicaHosts | list | `[]` | Database read replica hosts |
+| config.db.readReplicaHosts | string | `""` | Database read replica hosts |
 | config.db.readReplicaHostsSecretKeyName | string | `"readReplicaHosts"` | The database read replica hosts will be read from this `key` in the specified Secret, when `db.secretName` is set. |
 | config.db.port | string | `nil` | Database port |
 | config.db.portSecretKeyName | string | `"port"` | The database port will be read from this `key` in the specified Secret, when `db.secretName` is set. |

--- a/charts/reports-server/README.md
+++ b/charts/reports-server/README.md
@@ -1,6 +1,6 @@
 # reports-server
 
-![Version: 0.1.20](https://img.shields.io/badge/Version-0.1.20-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.1.18](https://img.shields.io/badge/AppVersion-v0.1.18-informational?style=flat-square)
+![Version: 0.1.22](https://img.shields.io/badge/Version-0.1.22-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.1.19](https://img.shields.io/badge/AppVersion-v0.1.19-informational?style=flat-square)
 
 TODO
 

--- a/charts/reports-server/templates/etcd.yaml
+++ b/charts/reports-server/templates/etcd.yaml
@@ -66,7 +66,7 @@ spec:
               topologyKey: "kubernetes.io/hostname"
       containers:
       - name: etcd
-        image: ghcr.io/nirmata/etcd:v3.5.18-cve-free
+        image:  "{{ .Values.config.etcd.image.registry }}/{{ .Values.config.etcd.image.repository }}:{{ .Values.config.etcd.image.tag }}"
         imagePullPolicy: IfNotPresent
         ports:
         - name: etcd-client

--- a/charts/reports-server/values.yaml
+++ b/charts/reports-server/values.yaml
@@ -183,6 +183,10 @@ service:
 config:
 
   etcd:
+    image:
+      registry: ghcr.io
+      repository: nirmata/etcd
+      tag: v3.5.18-cve-free
     enabled: true
     endpoints: ~
     insecure: true

--- a/config/install-etcd.yaml
+++ b/config/install-etcd.yaml
@@ -301,7 +301,7 @@ spec:
             - name: DB_HOST
               value: "reports-server-cluster-rw.reports-server"
             - name: DB_READ_REPLICA_HOSTS
-              value: "[]"
+              value: ""
             - name: DB_PORT
               value: 
             - name: DB_DATABASE
@@ -395,7 +395,7 @@ spec:
               topologyKey: "kubernetes.io/hostname"
       containers:
       - name: etcd
-        image: ghcr.io/nirmata/etcd:v3.5.18-cve-free
+        image:  "ghcr.io/nirmata/etcd:v3.5.18-cve-free"
         imagePullPolicy: IfNotPresent
         ports:
         - name: etcd-client

--- a/config/install-etcd.yaml
+++ b/config/install-etcd.yaml
@@ -10,10 +10,10 @@ metadata:
   name: reports-server
   namespace: reports-server
   labels:
-    helm.sh/chart: reports-server-0.1.20
+    helm.sh/chart: reports-server-0.1.22
     app.kubernetes.io/name: reports-server
     app.kubernetes.io/instance: reports-server
-    app.kubernetes.io/version: "v0.1.18"
+    app.kubernetes.io/version: "v0.1.19"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -27,10 +27,10 @@ metadata:
   name: reports-server
   namespace: reports-server
   labels:
-    helm.sh/chart: reports-server-0.1.20
+    helm.sh/chart: reports-server-0.1.22
     app.kubernetes.io/name: reports-server
     app.kubernetes.io/instance: reports-server
-    app.kubernetes.io/version: "v0.1.18"
+    app.kubernetes.io/version: "v0.1.19"
     app.kubernetes.io/managed-by: Helm
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -41,10 +41,10 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-admin: 'true'
     rbac.authorization.k8s.io/aggregate-to-edit: 'true'
     rbac.authorization.k8s.io/aggregate-to-view: 'true'
-    helm.sh/chart: reports-server-0.1.20
+    helm.sh/chart: reports-server-0.1.22
     app.kubernetes.io/name: reports-server
     app.kubernetes.io/instance: reports-server
-    app.kubernetes.io/version: "v0.1.18"
+    app.kubernetes.io/version: "v0.1.19"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -128,10 +128,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: reports-server
   labels:
-    helm.sh/chart: reports-server-0.1.20
+    helm.sh/chart: reports-server-0.1.22
     app.kubernetes.io/name: reports-server
     app.kubernetes.io/instance: reports-server
-    app.kubernetes.io/version: "v0.1.18"
+    app.kubernetes.io/version: "v0.1.19"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -148,10 +148,10 @@ metadata:
   name: reports-server
   namespace: reports-server
   labels:
-    helm.sh/chart: reports-server-0.1.20
+    helm.sh/chart: reports-server-0.1.22
     app.kubernetes.io/name: reports-server
     app.kubernetes.io/instance: reports-server
-    app.kubernetes.io/version: "v0.1.18"
+    app.kubernetes.io/version: "v0.1.19"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -168,10 +168,10 @@ metadata:
   name: reports-server
   namespace: kube-system
   labels:
-    helm.sh/chart: reports-server-0.1.20
+    helm.sh/chart: reports-server-0.1.22
     app.kubernetes.io/name: reports-server
     app.kubernetes.io/instance: reports-server
-    app.kubernetes.io/version: "v0.1.18"
+    app.kubernetes.io/version: "v0.1.19"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -188,10 +188,10 @@ metadata:
   name: reports-server
   namespace: reports-server
   labels:
-    helm.sh/chart: reports-server-0.1.20
+    helm.sh/chart: reports-server-0.1.22
     app.kubernetes.io/name: reports-server
     app.kubernetes.io/instance: reports-server
-    app.kubernetes.io/version: "v0.1.18"
+    app.kubernetes.io/version: "v0.1.19"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -209,10 +209,10 @@ metadata:
   namespace: reports-server
   labels:
     app: etcd-reports-server
-    helm.sh/chart: reports-server-0.1.20
+    helm.sh/chart: reports-server-0.1.22
     app.kubernetes.io/name: reports-server
     app.kubernetes.io/instance: reports-server
-    app.kubernetes.io/version: "v0.1.18"
+    app.kubernetes.io/version: "v0.1.19"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -234,10 +234,10 @@ metadata:
   name: reports-server
   namespace: reports-server
   labels:
-    helm.sh/chart: reports-server-0.1.20
+    helm.sh/chart: reports-server-0.1.22
     app.kubernetes.io/name: reports-server
     app.kubernetes.io/instance: reports-server
-    app.kubernetes.io/version: "v0.1.18"
+    app.kubernetes.io/version: "v0.1.19"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -256,10 +256,10 @@ metadata:
   name: reports-server
   namespace: reports-server
   labels:
-    helm.sh/chart: reports-server-0.1.20
+    helm.sh/chart: reports-server-0.1.22
     app.kubernetes.io/name: reports-server
     app.kubernetes.io/instance: reports-server
-    app.kubernetes.io/version: "v0.1.18"
+    app.kubernetes.io/version: "v0.1.19"
     app.kubernetes.io/managed-by: Helm
 spec:
   strategy:
@@ -273,10 +273,10 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: reports-server-0.1.20
+        helm.sh/chart: reports-server-0.1.22
         app.kubernetes.io/name: reports-server
         app.kubernetes.io/instance: reports-server
-        app.kubernetes.io/version: "v0.1.18"
+        app.kubernetes.io/version: "v0.1.19"
         app.kubernetes.io/managed-by: Helm
     spec:
       priorityClassName: system-cluster-critical
@@ -360,10 +360,10 @@ metadata:
   name: etcd
   labels:
     app: etcd-reports-server
-    helm.sh/chart: reports-server-0.1.20
+    helm.sh/chart: reports-server-0.1.22
     app.kubernetes.io/name: reports-server
     app.kubernetes.io/instance: reports-server
-    app.kubernetes.io/version: "v0.1.18"
+    app.kubernetes.io/version: "v0.1.19"
     app.kubernetes.io/managed-by: Helm
 spec:
   serviceName: etcd
@@ -509,10 +509,10 @@ metadata:
   name: v1alpha2.wgpolicyk8s.io
   namespace: reports-server
   labels:
-    helm.sh/chart: reports-server-0.1.20
+    helm.sh/chart: reports-server-0.1.22
     app.kubernetes.io/name: reports-server
     app.kubernetes.io/instance: reports-server
-    app.kubernetes.io/version: "v0.1.18"
+    app.kubernetes.io/version: "v0.1.19"
     app.kubernetes.io/managed-by: Helm
     kube-aggregator.kubernetes.io/automanaged: "false"
   annotations:
@@ -533,10 +533,10 @@ metadata:
   name: v1.reports.kyverno.io
   namespace: reports-server
   labels:
-    helm.sh/chart: reports-server-0.1.20
+    helm.sh/chart: reports-server-0.1.22
     app.kubernetes.io/name: reports-server
     app.kubernetes.io/instance: reports-server
-    app.kubernetes.io/version: "v0.1.18"
+    app.kubernetes.io/version: "v0.1.19"
     app.kubernetes.io/managed-by: Helm
     kube-aggregator.kubernetes.io/automanaged: "false"
   annotations:

--- a/config/install.yaml
+++ b/config/install.yaml
@@ -301,7 +301,7 @@ spec:
             - name: DB_HOST
               value: "reports-server-cluster-rw.reports-server"
             - name: DB_READ_REPLICA_HOSTS
-              value: "[]"
+              value: ""
             - name: DB_PORT
               value: 
             - name: DB_DATABASE
@@ -395,7 +395,7 @@ spec:
               topologyKey: "kubernetes.io/hostname"
       containers:
       - name: etcd
-        image: ghcr.io/nirmata/etcd:v3.5.18-cve-free
+        image:  "ghcr.io/nirmata/etcd:v3.5.18-cve-free"
         imagePullPolicy: IfNotPresent
         ports:
         - name: etcd-client

--- a/config/install.yaml
+++ b/config/install.yaml
@@ -10,10 +10,10 @@ metadata:
   name: reports-server
   namespace: reports-server
   labels:
-    helm.sh/chart: reports-server-0.1.20
+    helm.sh/chart: reports-server-0.1.22
     app.kubernetes.io/name: reports-server
     app.kubernetes.io/instance: reports-server
-    app.kubernetes.io/version: "v0.1.18"
+    app.kubernetes.io/version: "v0.1.19"
     app.kubernetes.io/managed-by: Helm
 spec:
   selector:
@@ -27,10 +27,10 @@ metadata:
   name: reports-server
   namespace: reports-server
   labels:
-    helm.sh/chart: reports-server-0.1.20
+    helm.sh/chart: reports-server-0.1.22
     app.kubernetes.io/name: reports-server
     app.kubernetes.io/instance: reports-server
-    app.kubernetes.io/version: "v0.1.18"
+    app.kubernetes.io/version: "v0.1.19"
     app.kubernetes.io/managed-by: Helm
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -41,10 +41,10 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-admin: 'true'
     rbac.authorization.k8s.io/aggregate-to-edit: 'true'
     rbac.authorization.k8s.io/aggregate-to-view: 'true'
-    helm.sh/chart: reports-server-0.1.20
+    helm.sh/chart: reports-server-0.1.22
     app.kubernetes.io/name: reports-server
     app.kubernetes.io/instance: reports-server
-    app.kubernetes.io/version: "v0.1.18"
+    app.kubernetes.io/version: "v0.1.19"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -128,10 +128,10 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: reports-server
   labels:
-    helm.sh/chart: reports-server-0.1.20
+    helm.sh/chart: reports-server-0.1.22
     app.kubernetes.io/name: reports-server
     app.kubernetes.io/instance: reports-server
-    app.kubernetes.io/version: "v0.1.18"
+    app.kubernetes.io/version: "v0.1.19"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -148,10 +148,10 @@ metadata:
   name: reports-server
   namespace: reports-server
   labels:
-    helm.sh/chart: reports-server-0.1.20
+    helm.sh/chart: reports-server-0.1.22
     app.kubernetes.io/name: reports-server
     app.kubernetes.io/instance: reports-server
-    app.kubernetes.io/version: "v0.1.18"
+    app.kubernetes.io/version: "v0.1.19"
     app.kubernetes.io/managed-by: Helm
 rules:
 - apiGroups:
@@ -168,10 +168,10 @@ metadata:
   name: reports-server
   namespace: kube-system
   labels:
-    helm.sh/chart: reports-server-0.1.20
+    helm.sh/chart: reports-server-0.1.22
     app.kubernetes.io/name: reports-server
     app.kubernetes.io/instance: reports-server
-    app.kubernetes.io/version: "v0.1.18"
+    app.kubernetes.io/version: "v0.1.19"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -188,10 +188,10 @@ metadata:
   name: reports-server
   namespace: reports-server
   labels:
-    helm.sh/chart: reports-server-0.1.20
+    helm.sh/chart: reports-server-0.1.22
     app.kubernetes.io/name: reports-server
     app.kubernetes.io/instance: reports-server
-    app.kubernetes.io/version: "v0.1.18"
+    app.kubernetes.io/version: "v0.1.19"
     app.kubernetes.io/managed-by: Helm
 roleRef:
   apiGroup: rbac.authorization.k8s.io
@@ -209,10 +209,10 @@ metadata:
   namespace: reports-server
   labels:
     app: etcd-reports-server
-    helm.sh/chart: reports-server-0.1.20
+    helm.sh/chart: reports-server-0.1.22
     app.kubernetes.io/name: reports-server
     app.kubernetes.io/instance: reports-server
-    app.kubernetes.io/version: "v0.1.18"
+    app.kubernetes.io/version: "v0.1.19"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -234,10 +234,10 @@ metadata:
   name: reports-server
   namespace: reports-server
   labels:
-    helm.sh/chart: reports-server-0.1.20
+    helm.sh/chart: reports-server-0.1.22
     app.kubernetes.io/name: reports-server
     app.kubernetes.io/instance: reports-server
-    app.kubernetes.io/version: "v0.1.18"
+    app.kubernetes.io/version: "v0.1.19"
     app.kubernetes.io/managed-by: Helm
 spec:
   type: ClusterIP
@@ -256,10 +256,10 @@ metadata:
   name: reports-server
   namespace: reports-server
   labels:
-    helm.sh/chart: reports-server-0.1.20
+    helm.sh/chart: reports-server-0.1.22
     app.kubernetes.io/name: reports-server
     app.kubernetes.io/instance: reports-server
-    app.kubernetes.io/version: "v0.1.18"
+    app.kubernetes.io/version: "v0.1.19"
     app.kubernetes.io/managed-by: Helm
 spec:
   strategy:
@@ -273,10 +273,10 @@ spec:
   template:
     metadata:
       labels:
-        helm.sh/chart: reports-server-0.1.20
+        helm.sh/chart: reports-server-0.1.22
         app.kubernetes.io/name: reports-server
         app.kubernetes.io/instance: reports-server
-        app.kubernetes.io/version: "v0.1.18"
+        app.kubernetes.io/version: "v0.1.19"
         app.kubernetes.io/managed-by: Helm
     spec:
       priorityClassName: system-cluster-critical
@@ -360,10 +360,10 @@ metadata:
   name: etcd
   labels:
     app: etcd-reports-server
-    helm.sh/chart: reports-server-0.1.20
+    helm.sh/chart: reports-server-0.1.22
     app.kubernetes.io/name: reports-server
     app.kubernetes.io/instance: reports-server
-    app.kubernetes.io/version: "v0.1.18"
+    app.kubernetes.io/version: "v0.1.19"
     app.kubernetes.io/managed-by: Helm
 spec:
   serviceName: etcd
@@ -509,10 +509,10 @@ metadata:
   name: v1alpha2.wgpolicyk8s.io
   namespace: reports-server
   labels:
-    helm.sh/chart: reports-server-0.1.20
+    helm.sh/chart: reports-server-0.1.22
     app.kubernetes.io/name: reports-server
     app.kubernetes.io/instance: reports-server
-    app.kubernetes.io/version: "v0.1.18"
+    app.kubernetes.io/version: "v0.1.19"
     app.kubernetes.io/managed-by: Helm
     kube-aggregator.kubernetes.io/automanaged: "false"
   annotations:
@@ -533,10 +533,10 @@ metadata:
   name: v1.reports.kyverno.io
   namespace: reports-server
   labels:
-    helm.sh/chart: reports-server-0.1.20
+    helm.sh/chart: reports-server-0.1.22
     app.kubernetes.io/name: reports-server
     app.kubernetes.io/instance: reports-server
-    app.kubernetes.io/version: "v0.1.18"
+    app.kubernetes.io/version: "v0.1.19"
     app.kubernetes.io/managed-by: Helm
     kube-aggregator.kubernetes.io/automanaged: "false"
   annotations:


### PR DESCRIPTION
With no passing of the image, registry:

```

.PHONY: kind-install-etcd
kind-install-etcd: $(HELM) kind-load ## Build image, load it in kind cluster and deploy helm chart
	@echo Install chart... >&2
	@$(HELM) upgrade --install reports-server --namespace reports-server --create-namespace --wait ./charts/reports-server \
		--set image.registry=$(KO_REGISTRY) \
		--set config.etcd.enabled=true \
		--set postgresql.enabled=false \
		--set image.repository=$(PACKAGE) \
		--set image.tag=$(GIT_SHA) \
		--set config.etcd.storage=$(ETCD_STORAGE_SIZE)
		
		
make kind-install-etcd
Build image with ko...
2025/05/20 15:43:54 Using base cgr.dev/chainguard/static:latest@sha256:8d1a96321dca0e8e7848b7db2d431191f15e7e302faa1428100bbab351d42c7a for github.com/kyverno/reports-server
2025/05/20 15:43:55 Building github.com/kyverno/reports-server for linux/arm64
2025/05/20 15:43:56 Loading ko.local/github.com/kyverno/reports-server:7b2dbbc2275f41f3235d5afb50b7a4d0b18c3ec9734b08404a8997a4aa57f941
2025/05/20 15:43:58 Loaded ko.local/github.com/kyverno/reports-server:7b2dbbc2275f41f3235d5afb50b7a4d0b18c3ec9734b08404a8997a4aa57f941
2025/05/20 15:43:58 Adding tag ca019dd4c99aed4f5e7e1b61e7623def9040bcd7
2025/05/20 15:43:58 Added tag ca019dd4c99aed4f5e7e1b61e7623def9040bcd7
ko.local/github.com/kyverno/reports-server:7b2dbbc2275f41f3235d5afb50b7a4d0b18c3ec9734b08404a8997a4aa57f941
Load image...
Image: "ko.local/github.com/kyverno/reports-server:ca019dd4c99aed4f5e7e1b61e7623def9040bcd7" with ID "sha256:c354dd036ba60174a4f777763ee8edc08606e9ca331c502f1c11e3f4771e8e8e" not yet present on node "kind-control-plane", loading...
Install chart...
Release "reports-server" does not exist. Installing it now.
NAME: reports-server
LAST DEPLOYED: Tue May 20 15:44:02 2025
NAMESPACE: reports-server
STATUS: deployed
REVISION: 1
TEST SUITE: None

kubectl describe pod etcd-0  -n reports-server
Name:             etcd-0
Namespace:        reports-server
Priority:         0
Service Account:  default
Node:             kind-control-plane/**********
Start Time:       Tue, 20 May 2025 15:44:07 +0530
Labels:           app=etcd-reports-server
                  apps.kubernetes.io/pod-index=0
                  controller-revision-hash=etcd-5fdd858759
                  statefulset.kubernetes.io/pod-name=etcd-0
Annotations:      serviceName: etcd
Status:           Running
IP:               ***********
IPs:
  IP:           ***********
Controlled By:  StatefulSet/etcd
Containers:
  etcd:
    Container ID:  containerd://452713bac50f595c3fe74b708fa095dd9c7a3d7d763f3a1a063b3a79865feedb
    Image:         ghcr.io/nirmata/etcd:v3.5.18-cve-free
    Image ID:      ghcr.io/nirmata/etcd@sha256:6033af74b23bc6b0a24de9455a4a90c3ee7aca3359807fd248b1dc86a5eb2816
    Ports:         2379/TCP, 2380/TCP, 8080/TCP
    Host Ports:    0/TCP, 0/TCP, 0/TCP
    Command:
      /usr/local/bin/etcd
    Args:
      --name=$(HOSTNAME)
      --data-dir=/data
      --wal-dir=/data/wal
      --listen-peer-urls=$(URI_SCHEME)://*******:2380
      --listen-client-urls=$(URI_SCHEME)://*******:2379
      --advertise-client-urls=$(URI_SCHEME)://$(HOSTNAME).$(SERVICE_NAME):2379
      --initial-cluster-state=new
      --initial-cluster-token=etcd-$(K8S_NAMESPACE)
      --initial-cluster=etcd-0=$(URI_SCHEME)://etcd-0.$(SERVICE_NAME):2380,etcd-1=$(URI_SCHEME)://etcd-1.$(SERVICE_NAME):2380,etcd-2=$(URI_SCHEME)://etcd-2.$(SERVICE_NAME):2380
      --initial-advertise-peer-urls=$(URI_SCHEME)://$(HOSTNAME).$(SERVICE_NAME):2380
      --listen-metrics-urls=http://*******:8080
      --quota-backend-bytes=1932735283
    State:          Running
      Started:      Tue, 20 May 2025 15:44:13 +0530
    Ready:          True
    Restart Count:  0
    Liveness:       http-get http://:8080/livez delay=15s timeout=5s period=10s #success=1 #failure=3
    Readiness:      http-get http://:8080/readyz delay=10s timeout=5s period=5s #success=1 #failure=30
    Environment:
      K8S_NAMESPACE:      reports-server (v1:metadata.namespace)
      HOSTNAME:           etcd-0 (v1:metadata.name)
      SERVICE_NAME:        (v1:metadata.annotations['serviceName'])
      ETCDCTL_ENDPOINTS:  $(HOSTNAME).$(SERVICE_NAME):2379
      URI_SCHEME:         http
    Mounts:
      /data from etcd-data (rw)
      /var/run/secrets/kubernetes.io/serviceaccount from kube-api-access-bgwj5 (ro)
Conditions:
  Type                        Status
  PodReadyToStartContainers   True 
  Initialized                 True 
  Ready                       True 
  ContainersReady             True 
  PodScheduled                True 
Volumes:
  etcd-data:
    Type:       PersistentVolumeClaim (a reference to a PersistentVolumeClaim in the same namespace)
    ClaimName:  etcd-data-etcd-0
    ReadOnly:   false
  kube-api-access-bgwj5:
    Type:                    Projected (a volume that contains injected data from multiple sources)
    TokenExpirationSeconds:  3607
    ConfigMapName:           kube-root-ca.crt
    ConfigMapOptional:       <nil>
    DownwardAPI:             true
QoS Class:                   BestEffort
Node-Selectors:              <none>
Tolerations:                 node.kubernetes.io/not-ready:NoExecute op=Exists for 300s
                             node.kubernetes.io/unreachable:NoExecute op=Exists for 300s
Events:
  Type     Reason     Age   From               Message
  ----     ------     ----  ----               -------
  Normal   Scheduled  79s   default-scheduler  Successfully assigned reports-server/etcd-0 to kind-control-plane
  Normal   Pulling    79s   kubelet            Pulling image "ghcr.io/nirmata/etcd:v3.5.18-cve-free"
  Normal   Pulled     73s   kubelet            Successfully pulled image "ghcr.io/nirmata/etcd:v3.5.18-cve-free" in 694ms (5.644s including waiting). Image size: 20733862 bytes.
  Normal   Created    73s   kubelet            Created container etcd
  Normal   Started    73s   kubelet            Started container etcd
  Warning  Unhealthy  54s   kubelet            Readiness probe failed: Get "http://***********:8080/readyz": context deadline exceeded (Client.Timeout exceeded while awaiting headers)
  Warning  Unhealthy  51s   kubelet            Readiness probe failed: HTTP probe failed with statuscode: 503
```

with passing of the image and registry:
```
.PHONY: kind-install-etcd-with-config-of-images
kind-install-etcd-with-config-of-images: $(HELM) kind-load ## Build image, load it in kind cluster and deploy helm chart
	@echo Install chart... >&2
	@$(HELM) upgrade --install reports-server --namespace reports-server --create-namespace --wait ./charts/reports-server \
		--set image.registry=$(KO_REGISTRY) \
		--set config.etcd.enabled=true \
		--set postgresql.enabled=false \
		--set image.repository=$(PACKAGE) \
		--set image.tag=$(GIT_SHA) \
		--set config.etcd.storage=$(ETCD_STORAGE_SIZE) \
		--set config.etcd.image.registry=registry.io \
		--set config.etcd.image.repository=image/repository \
		--set config.etcd.image.tag=image-tag
		
kubectl describe pod etcd-0 -n reports-server
Name:             etcd-0
Namespace:        reports-server
Priority:         0
Service Account:  default
Node:             kind-control-plane/**********
Start Time:       Tue, 20 May 2025 15:50:31 +0530
Labels:           app=etcd-reports-server
                  apps.kubernetes.io/pod-index=0
                  controller-revision-hash=etcd-7b5b6748d
                  statefulset.kubernetes.io/pod-name=etcd-0
Annotations:      serviceName: etcd
Status:           Pending
IP:               ***********
IPs:
  IP:           ***********
Controlled By:  StatefulSet/etcd
Containers:
  etcd:
    Container ID:  
    Image:         registry.io/image/repository:image-tag
```