### PR TITLE
[NDEV-23163]: Image pull secrets made configurable in the etcd chart

### DIFF
--- a/charts/reports-server/README.md
+++ b/charts/reports-server/README.md
@@ -69,9 +69,10 @@ helm install reports-server --namespace reports-server --create-namespace report
 | affinity | object | `{}` | Affinity |
 | service.type | string | `"ClusterIP"` | Service type |
 | service.port | int | `443` | Service port |
-| config.etcd.image.registry | string | `"ghcr.io"` |  |
-| config.etcd.image.repository | string | `"nirmata/etcd"` |  |
-| config.etcd.image.tag | string | `"v3.5.18-cve-free"` |  |
+| config.etcd.image.registry | string | `"ghcr.io"` | Image registry |
+| config.etcd.image.repository | string | `"nirmata/etcd"` | Image repository |
+| config.etcd.image.tag | string | `"v3.5.18-cve-free"` | Image tag |
+| config.etcd.imagePullSecrets | list | `[]` | Image pull secrets |
 | config.etcd.enabled | bool | `true` |  |
 | config.etcd.endpoints | string | `nil` |  |
 | config.etcd.insecure | bool | `true` |  |

--- a/charts/reports-server/templates/etcd.yaml
+++ b/charts/reports-server/templates/etcd.yaml
@@ -52,6 +52,9 @@ spec:
 {{- if .Values.config.etcd.tolerations }}
       tolerations: {{ toYaml .Values.config.etcd.tolerations | nindent 8 }}
 {{- end }}
+{{- if .Values.config.etcd.imagePullSecrets }}
+      imagePullSecrets: {{ toYaml .Values.config.etcd.imagePullSecrets | nindent 8 }}
+{{- end }}
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/charts/reports-server/values.yaml
+++ b/charts/reports-server/values.yaml
@@ -184,9 +184,16 @@ config:
 
   etcd:
     image:
+      # -- Image registry
       registry: ghcr.io
+      # -- Image repository
       repository: nirmata/etcd
+      # -- Image tag
       tag: v3.5.18-cve-free
+
+    # -- Image pull secrets
+    imagePullSecrets: []
+
     enabled: true
     endpoints: ~
     insecure: true


### PR DESCRIPTION
```
helm upgrade --install report-server ./charts/reports-server \
  --namespace kyverno --create-namespace \
  --set config.etcd.enabled=true \
  --set config.etcd.image.registry=registry.io \
  --set config.etcd.image.repository=image/repository \
  --set config.etcd.image.tag=image-tag \
  --set 'config.etcd.imagePullSecrets[0].name=test-registry-secret'
Release "report-server" does not exist. Installing it now.


kubectl get pods etcd-0 -n kyverno -o yaml
apiVersion: v1
kind: Pod
metadata:
  annotations:
    serviceName: etcd
  creationTimestamp: "2025-05-21T06:22:21Z"
  generateName: etcd-
  labels:
    app: etcd-reports-server
    apps.kubernetes.io/pod-index: "0"
    controller-revision-hash: etcd-7b5ff9bbff
    statefulset.kubernetes.io/pod-name: etcd-0
  name: etcd-0
  namespace: kyverno
  ownerReferences:
  - apiVersion: apps/v1
    blockOwnerDeletion: true
    controller: true
    kind: StatefulSet
    name: etcd
    uid: ************************************
  resourceVersion: "635"
  uid: ************************************
spec:
  affinity:
    podAntiAffinity:
      preferredDuringSchedulingIgnoredDuringExecution:
      - podAffinityTerm:
          labelSelector:
            matchExpressions:
            - key: app
              operator: In
              values:
              - etcd-reports-server
          topologyKey: kubernetes.io/hostname
        weight: 1
  containers:
  - args:
    - --name=$(HOSTNAME)
    - --data-dir=/data
    - --wal-dir=/data/wal
    - --listen-peer-urls=$(URI_SCHEME)://*******:2380
    - --listen-client-urls=$(URI_SCHEME)://*******:2379
    - --advertise-client-urls=$(URI_SCHEME)://$(HOSTNAME).$(SERVICE_NAME):2379
    - --initial-cluster-state=new
    - --initial-cluster-token=etcd-$(K8S_NAMESPACE)
    - --initial-cluster=etcd-0=$(URI_SCHEME)://etcd-0.$(SERVICE_NAME):2380,etcd-1=$(URI_SCHEME)://etcd-1.$(SERVICE_NAME):2380,etcd-2=$(URI_SCHEME)://etcd-2.$(SERVICE_NAME):2380
    - --initial-advertise-peer-urls=$(URI_SCHEME)://$(HOSTNAME).$(SERVICE_NAME):2380
    - --listen-metrics-urls=http://*******:8080
    - --quota-backend-bytes=1932735283
    command:
    - /usr/local/bin/etcd
    env:
    - name: K8S_NAMESPACE
      valueFrom:
        fieldRef:
          apiVersion: v1
          fieldPath: metadata.namespace
    - name: HOSTNAME
      valueFrom:
        fieldRef:
          apiVersion: v1
          fieldPath: metadata.name
    - name: SERVICE_NAME
      valueFrom:
        fieldRef:
          apiVersion: v1
          fieldPath: metadata.annotations['serviceName']
    - name: ETCDCTL_ENDPOINTS
      value: $(HOSTNAME).$(SERVICE_NAME):2379
    - name: URI_SCHEME
      value: http
    image: registry.io/image/repository:image-tag
    imagePullPolicy: IfNotPresent
    livenessProbe:
      failureThreshold: 3
      httpGet:
        path: /livez
        port: 8080
        scheme: HTTP
      initialDelaySeconds: 15
      periodSeconds: 10
      successThreshold: 1
      timeoutSeconds: 5
    name: etcd
    ports:
    - containerPort: 2379
      name: etcd-client
      protocol: TCP
    - containerPort: 2380
      name: etcd-server
      protocol: TCP
    - containerPort: 8080
      name: etcd-metrics
      protocol: TCP
    readinessProbe:
      failureThreshold: 30
      httpGet:
        path: /readyz
        port: 8080
        scheme: HTTP
      initialDelaySeconds: 10
      periodSeconds: 5
      successThreshold: 1
      timeoutSeconds: 5
    resources: {}
    terminationMessagePath: /dev/termination-log
    terminationMessagePolicy: File
    volumeMounts:
    - mountPath: /data
      name: etcd-data
    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
      name: kube-api-access-rhlcn
      readOnly: true
  dnsPolicy: ClusterFirst
  enableServiceLinks: true
  hostname: etcd-0
  imagePullSecrets:
  - name: test-registry-secret
  nodeName: kind-control-plane
  preemptionPolicy: PreemptLowerPriority
  priority: 0
  restartPolicy: Always
  schedulerName: default-scheduler
  securityContext: {}
  serviceAccount: default
  serviceAccountName: default
  subdomain: etcd
  terminationGracePeriodSeconds: 30
  tolerations:
  - effect: NoExecute
    key: node.kubernetes.io/not-ready
    operator: Exists
    tolerationSeconds: 300
  - effect: NoExecute
    key: node.kubernetes.io/unreachable
    operator: Exists
    tolerationSeconds: 300
  volumes:
  - name: etcd-data
    persistentVolumeClaim:
      claimName: etcd-data-etcd-0
  - name: kube-api-access-rhlcn
    projected:
      defaultMode: 420
      sources:
      - serviceAccountToken:
          expirationSeconds: 3607
          path: token
      - configMap:
          items:
          - key: ca.crt
            path: ca.crt
          name: kube-root-ca.crt
      - downwardAPI:
          items:
          - fieldRef:
              apiVersion: v1
              fieldPath: metadata.namespace
            path: namespace
status:
  conditions:
  - lastProbeTime: null
    lastTransitionTime: "2025-05-21T06:22:37Z"
    status: "False"
    type: PodReadyToStartContainers
  - lastProbeTime: null
    lastTransitionTime: "2025-05-21T06:22:37Z"
    status: "True"
    type: Initialized
  - lastProbeTime: null
    lastTransitionTime: "2025-05-21T06:22:37Z"
    message: 'containers with unready status: [etcd]'
    reason: ContainersNotReady
    status: "False"
    type: Ready
  - lastProbeTime: null
    lastTransitionTime: "2025-05-21T06:22:37Z"
    message: 'containers with unready status: [etcd]'
    reason: ContainersNotReady
    status: "False"
    type: ContainersReady
  - lastProbeTime: null
    lastTransitionTime: "2025-05-21T06:22:37Z"
    status: "True"
    type: PodScheduled
  containerStatuses:
  - image: registry.io/image/repository:image-tag
    imageID: ""
    lastState: {}
    name: etcd
    ready: false
    restartCount: 0
    started: false
    state:
      waiting:
        reason: ContainerCreating
    volumeMounts:
    - mountPath: /data
      name: etcd-data
    - mountPath: /var/run/secrets/kubernetes.io/serviceaccount
      name: kube-api-access-rhlcn
      readOnly: true
      recursiveReadOnly: Disabled
  hostIP: **********
  hostIPs:
  - ip: **********
  phase: Pending
  qosClass: BestEffort
  startTime: "2025-05-21T06:22:37Z"
```