### PR TITLE
fix: prevent helm uninstall timeout by removing pod wait from cleanup hook

### DIFF
--- a/charts/reports-server/Chart.yaml
+++ b/charts/reports-server/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: reports-server
 type: application
-version: 0.1.26
+version: 0.1.27
 appVersion: v0.1.20
 keywords:
 - kubernetes

--- a/charts/reports-server/templates/hooks/pre-delete-api-service-cleanup.yaml
+++ b/charts/reports-server/templates/hooks/pre-delete-api-service-cleanup.yaml
@@ -12,7 +12,8 @@ metadata:
     helm.sh/hook-delete-policy: before-hook-creation,hook-succeeded,hook-failed
     helm.sh/hook-weight: "100"
 spec:
-  backoffLimit: 2
+  backoffLimit: 1
+  activeDeadlineSeconds: 300
   template:
     metadata:
       {{- with .Values.apiServicesManagement.podAnnotations }}
@@ -44,8 +45,42 @@ spec:
             - '-c'
             - |-
               set -euo pipefail
-              kubectl wait -n {{ $.Release.Namespace }} pod --for=condition=ready -l app.kubernetes.io/name={{ include "reports-server.name" . }} --timeout=120s
-              kubectl delete apiservice v1alpha2.wgpolicyk8s.io v1.reports.kyverno.io --ignore-not-found=true
+              
+              echo "Starting cleanup of reports-server API services..."
+              
+              # Delete API services individually with retry logic
+              # This approach is more reliable than deleting multiple services at once
+              api_services="v1alpha2.wgpolicyk8s.io v1.reports.kyverno.io"
+              success_count=0
+              total_count=0
+              
+              for api_service in $api_services; do
+                total_count=$((total_count + 1))
+                echo "Attempting to delete API service: $api_service"
+                
+                attempt=1
+                while [ $attempt -le 3 ]; do
+                  if kubectl delete apiservice "$api_service" --ignore-not-found=true; then
+                    echo "Successfully deleted API service: $api_service"
+                    success_count=$((success_count + 1))
+                    break
+                  else
+                    echo "Attempt $attempt failed to delete API service: $api_service"
+                    if [ $attempt -lt 3 ]; then
+                      echo "Retrying in 2 seconds..."
+                      sleep 2
+                    else
+                      echo "WARNING: Failed to delete API service $api_service after 3 attempts"
+                    fi
+                  fi
+                  attempt=$((attempt + 1))
+                done
+              done
+              
+              echo "API services cleanup completed: $success_count/$total_count successful"
+              
+              # Exit successfully even if some deletions failed - cleanup is best effort during uninstall
+              exit 0
           {{- with .Values.apiServicesManagement.securityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}


### PR DESCRIPTION
The pre-delete hook was waiting for reports-server pods to be ready before cleaning up API services, causing helm uninstall to timeout when pods were failing. API service cleanup doesn't require a healthy pods, so remove the wait and add retry logic for reliability.